### PR TITLE
Allow specifying the version via DSL keyword

### DIFF
--- a/lib/mcp/delegator.rb
+++ b/lib/mcp/delegator.rb
@@ -15,6 +15,6 @@ module MCP
       end
     end
 
-    delegate :name, :resource, :tool
+    delegate :name, :version, :resource, :tool
   end
 end

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -9,7 +9,7 @@ module MCP
     attr_writer :name, :version
     attr_reader :initialized
 
-    def initialize(name:, version: '0.1.0')
+    def initialize(name:, version: "0.1.0")
       @name = name
       @version = version
       @app = App.new

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -9,7 +9,7 @@ module MCP
     attr_writer :name, :version
     attr_reader :initialized
 
-    def initialize(name:, version: VERSION)
+    def initialize(name:, version: '0.1.0')
       @name = name
       @version = version
       @app = App.new

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -6,7 +6,7 @@ require "uri"
 
 module MCP
   class Server
-    attr_writer :name
+    attr_writer :name, :version
     attr_reader :initialized
 
     def initialize(name:, version: VERSION)
@@ -21,6 +21,12 @@ module MCP
       return @name if value.nil?
 
       @name = value
+    end
+
+    def version(value = nil)
+      return @version if value.nil?
+
+      @version = value
     end
 
     def tool(name, &block)

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -6,7 +6,7 @@ require "uri"
 
 module MCP
   class Server
-    attr_accessor :name
+    attr_writer :name
     attr_reader :initialized
 
     def initialize(name:, version: VERSION)
@@ -17,7 +17,7 @@ module MCP
       @supported_protocol_versions = [PROTOCOL_VERSION]
     end
 
-    def name(value = nil) # standard:disable Lint/DuplicateMethods
+    def name(value = nil)
       return @name if value.nil?
 
       @name = value

--- a/test/mcp/delegator_test.rb
+++ b/test/mcp/delegator_test.rb
@@ -4,6 +4,16 @@ require_relative "../test_helper"
 
 module MCP
   class DelegatorTest < MCPTest::TestCase
+    def test_server_version
+      server = build_test_server
+      server.version "1.2.3"
+
+      assert_equal "1.2.3", server.version
+
+      initialize_response = initialize_server(server)
+      assert_equal '1.2.3', initialize_response[:result][:serverInfo][:version]
+    end
+
     def test_tool_registration
       server = Server.new(name: "test_server")
       initialize_server(server)

--- a/test/mcp/delegator_test.rb
+++ b/test/mcp/delegator_test.rb
@@ -11,7 +11,7 @@ module MCP
       assert_equal "1.2.3", server.version
 
       initialize_response = initialize_server(server)
-      assert_equal '1.2.3', initialize_response[:result][:serverInfo][:version]
+      assert_equal "1.2.3", initialize_response[:result][:serverInfo][:version]
     end
 
     def test_tool_registration

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -7,6 +7,7 @@ module MCP
     def test_server_initialization
       server = Server.new(name: "test_server")
       assert_equal "test_server", server.name
+      assert_equal "0.1.0", server.version
       refute server.initialized
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,7 +24,7 @@ module MCPTest
         },
         id: 1
       }
-      server.send(:handle_request, init_request)
+      initialize_response = server.send(:handle_request, init_request)
 
       init_notification = {
         jsonrpc: MCP::Constants::JSON_RPC_VERSION,
@@ -32,6 +32,8 @@ module MCPTest
         id: 2
       }
       server.send(:handle_request, init_notification)
+
+      initialize_response
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,10 @@ module MCPTest
   class TestCase < Minitest::Test
     protected
 
+    def build_test_server
+      MCP::Server.new(name: "test_server")
+    end
+
     def initialize_server(server)
       init_request = {
         jsonrpc: MCP::Constants::JSON_RPC_VERSION,


### PR DESCRIPTION
It's just something minor but if you want to start implementing and versioning your MCP server using this gem, you should be able to easily specify the version via DSL as you can specify the name.

Before this change the server just announced the gem version as server version.

I added a delegation for version similar to the name delegation.

I also added 2 minor improvements/suggestions to the test helper
- returning the initialize response for easy confirmation of content if needed
- Having a shortcut `build_test_server` method for test cases that really don't care about the name
  - Maybe you could even also add a `build_initialized_server` one too to avoid the repetition in cases where this is really just noise - but this is just personal style preference I'd say - feel free to ignore :D