### PR TITLE
Add client

### DIFF
--- a/examples/client_example.rb
+++ b/examples/client_example.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/mcp"
+
+begin
+  client = MCP::Client.new(
+    command: "ruby",
+    args: ["examples/hello_world.rb"]
+  )
+  client.connect
+
+  tools = client.list_tools
+  puts "available tools:"
+  puts tools.inspect
+
+  # execute greet tool
+  result = client.call_tool(
+    name: "greet",
+    args: {name: "MCP Client Example"}
+  )
+  puts "\nResult:"
+  puts result.inspect
+ensure
+  client.close
+end

--- a/lib/mcp.rb
+++ b/lib/mcp.rb
@@ -8,6 +8,7 @@ require_relative "mcp/constants"
 require_relative "mcp/app"
 require_relative "mcp/server"
 require_relative "mcp/delegator"
+require_relative "mcp/client"
 
 module MCP
   class << self

--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "securerandom"
+require_relative "constants"
+
+module MCP
+  class Client
+    attr_reader :command, :args, :process, :stdin, :stdout, :stderr, :wait_thread
+
+    def initialize(command:, args: [], name: "mcp-client", version: VERSION)
+      @command = command
+      @args = args
+      @process = nil
+      @name = name
+      @version = version
+    end
+
+    def connect
+      return if @process
+
+      start_server
+      initialize_connection
+      self
+    end
+
+    def running? = !@process.nil?
+
+    def list_tools
+      ensure_running
+      send_request({
+        jsonrpc: Constants::JSON_RPC_VERSION,
+        method: Constants::RequestMethods::TOOLS_LIST,
+        params: {},
+        id: SecureRandom.uuid
+      })
+    end
+
+    def call_tool(name:, args: {})
+      ensure_running
+      send_request({
+        jsonrpc: Constants::JSON_RPC_VERSION,
+        method: Constants::RequestMethods::TOOLS_CALL,
+        params: {
+          name: name,
+          arguments: args
+        },
+        id: SecureRandom.uuid
+      })
+    end
+
+    def close
+      return unless @process
+
+      @stdin.close
+      @stdout.close
+      @stderr.close
+      Process.kill("TERM", @process)
+      @wait_thread.join
+      @process = nil
+    rescue IOError, Errno::ESRCH
+      # プロセスが既に終了している場合は無視
+      @process = nil
+    end
+
+    private
+
+    def ensure_running
+      raise "Server process not running. Call #start first." unless running?
+    end
+
+    def initialize_connection
+      response = send_request({
+        jsonrpc: Constants::JSON_RPC_VERSION,
+        method: "initialize",
+        params: {
+          protocolVersion: Constants::PROTOCOL_VERSION,
+          client: {
+            name: @name,
+            version: @version
+          }
+        },
+        id: SecureRandom.uuid
+      })
+
+      @stdin.puts(JSON.generate({
+        jsonrpc: Constants::JSON_RPC_VERSION,
+        method: "notifications/initialized"
+      }))
+
+      response
+    end
+
+    def start_server
+      @stdin, @stdout, @stderr, @wait_thread = Open3.popen3(@command, *@args)
+      @process = @wait_thread.pid
+
+      Thread.new do
+        while (line = @stderr.gets)
+          warn "[MCP Server] #{line}"
+        end
+      rescue IOError
+        # ignore when stream is closed
+      end
+    end
+
+    def send_request(request)
+      @stdin.puts(JSON.generate(request))
+      response = @stdout.gets
+      raise "No response from server" unless response
+
+      result = JSON.parse(response, symbolize_names: true)
+      if result[:error]
+        raise "Server error: #{result[:error][:message]} (#{result[:error][:code]})"
+      end
+
+      result[:result]
+    rescue JSON::ParserError => e
+      raise "Invalid JSON response: #{e.message}"
+    end
+  end
+end

--- a/lib/mcp/constants.rb
+++ b/lib/mcp/constants.rb
@@ -3,6 +3,7 @@
 module MCP
   module Constants
     JSON_RPC_VERSION = "2.0"
+    PROTOCOL_VERSION = "2024-11-05"
 
     module ErrorCodes
       NOT_INITIALIZED = -32_002

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -3,6 +3,7 @@
 require "json"
 require "English"
 require "uri"
+require_relative "constants"
 
 module MCP
   class Server
@@ -14,7 +15,7 @@ module MCP
       @version = version
       @app = App.new
       @initialized = false
-      @supported_protocol_versions = [PROTOCOL_VERSION]
+      @supported_protocol_versions = [Constants::PROTOCOL_VERSION]
     end
 
     def name(value = nil) # standard:disable Lint/DuplicateMethods
@@ -113,7 +114,7 @@ module MCP
         jsonrpc: MCP::Constants::JSON_RPC_VERSION,
         id: request[:id],
         result: {
-          protocolVersion: PROTOCOL_VERSION,
+          protocolVersion: Constants::PROTOCOL_VERSION,
           capabilities: {
             logging: {},
             prompts: {

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  PROTOCOL_VERSION = "2024-11-05"
   VERSION = "0.2.0"
 end

--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "stringio"
+
+module MCP
+  class ClientTest < MCPTest::TestCase
+    class MockServer
+      attr_reader :input, :output, :error
+
+      def initialize
+        reset_streams
+      end
+
+      def reset_streams
+        @input = StringIO.new
+        @output = StringIO.new
+        @error = StringIO.new
+        @responses = []
+        @initialized = false
+      end
+
+      def start(*_args)
+        reset_streams
+        setup_init_response
+        wait_thread = create_mock_thread
+
+        [InputWrapper.new(@input, self), OutputWrapper.new(@output), @error, wait_thread]
+      end
+
+      def add_response(response)
+        @responses << response
+      end
+
+      private
+
+      def setup_init_response
+        @init_response = {
+          jsonrpc: Constants::JSON_RPC_VERSION,
+          result: {serverInfo: {name: "mock", version: "1.0.0"}},
+          id: 1
+        }
+      end
+
+      def create_mock_thread
+        thread = Thread.new {}
+        def thread.pid
+          12345
+        end
+        thread
+      end
+
+      def handle_request(request)
+        request_data = JSON.parse(request, symbolize_names: true)
+        case request_data[:method]
+        when MCP::Constants::RequestMethods::INITIALIZE
+          @initialized = true
+          @init_response
+        when MCP::Constants::RequestMethods::INITIALIZED
+          nil
+        else
+          return nil unless @initialized
+          return nil unless request_data[:id]
+          @responses.shift
+        end
+      end
+
+      class InputWrapper < StringIO
+        def initialize(stringio, server)
+          @stringio = stringio
+          @server = server
+        end
+
+        def puts(str)
+          @stringio.puts(str)
+          if (response = @server.send(:handle_request, str))
+            @server.output.write(JSON.generate(response) + "\n")
+            @server.output.rewind
+          end
+        end
+
+        def method_missing(method, *args, &block)
+          @stringio.send(method, *args, &block)
+        end
+
+        def respond_to_missing?(method, include_private = false)
+          @stringio.respond_to?(method, include_private)
+        end
+      end
+
+      class OutputWrapper < StringIO
+        def initialize(stringio)
+          @stringio = stringio
+        end
+
+        def gets
+          result = @stringio.gets
+          @stringio.rewind
+          result
+        end
+
+        def method_missing(method, *args, &block)
+          @stringio.send(method, *args, &block)
+        end
+
+        def respond_to_missing?(method, include_private = false)
+          @stringio.respond_to?(method, include_private)
+        end
+      end
+    end
+
+    def setup
+      @mock_server = MockServer.new
+      @client = Client.new(command: "mock")
+      with_mock_server(@mock_server) do
+        @client.connect
+      end
+    end
+
+    def teardown
+      @client.close if @client&.running?
+    end
+
+    def with_mock_server(mock_server)
+      Open3.stub :popen3, mock_server.method(:start) do
+        yield
+      end
+    end
+
+    def test_initialize
+      client = Client.new(command: "mock")
+      assert_equal "mock", client.command
+      assert_empty client.args
+      refute client.running?
+    end
+
+    def test_initialize_with_args
+      client = Client.new(command: "mock", args: ["--version"], name: "test-client", version: "1.0.0")
+      assert_equal "mock", client.command
+      assert_equal ["--version"], client.args
+      refute client.running?
+    end
+
+    def test_connect
+      assert @client.running?
+      assert_equal 12345, @client.process
+      assert @client.stdin
+      assert @client.stdout
+      assert @client.stderr
+      assert @client.wait_thread
+    end
+
+    def test_list_tools_without_connection
+      client = Client.new(command: "mock")
+      error = assert_raises(RuntimeError) { client.list_tools }
+      assert_match(/Server process not running/, error.message)
+    end
+
+    def test_call_tool_without_connection
+      client = Client.new(command: "mock")
+      error = assert_raises(RuntimeError) { client.call_tool(name: "test") }
+      assert_match(/Server process not running/, error.message)
+    end
+
+    def test_close_without_connection
+      client = Client.new(command: "mock")
+      client.close
+      refute client.running?
+    end
+
+    def test_list_tools
+      mock_server = MockServer.new
+      client = Client.new(command: "mock")
+
+      with_mock_server(mock_server) do
+        client.connect
+        mock_server.add_response({
+          jsonrpc: Constants::JSON_RPC_VERSION,
+          result: [{name: "test_tool", description: "Test tool"}],
+          id: 2
+        })
+
+        result = client.list_tools
+        assert_equal [{name: "test_tool", description: "Test tool"}], result
+      end
+    end
+
+    def test_call_tool
+      mock_server = MockServer.new
+      client = Client.new(command: "mock")
+
+      with_mock_server(mock_server) do
+        client.connect
+        mock_server.add_response({
+          jsonrpc: Constants::JSON_RPC_VERSION,
+          result: {success: true},
+          id: 2
+        })
+
+        result = client.call_tool(name: "test_tool", args: {key: "value"})
+        assert_equal({success: true}, result)
+      end
+    end
+  end
+end

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -16,7 +16,7 @@ module MCP
         jsonrpc: MCP::Constants::JSON_RPC_VERSION,
         method: MCP::Constants::RequestMethods::INITIALIZE,
         params: {
-          protocolVersion: PROTOCOL_VERSION,
+          protocolVersion: MCP::Constants::PROTOCOL_VERSION,
           capabilities: {},
           clientInfo: {
             name: "test_client",
@@ -29,7 +29,7 @@ module MCP
       response = server.send(:handle_request, request)
       assert_equal MCP::Constants::JSON_RPC_VERSION, response[:jsonrpc]
       assert_equal 1, response[:id]
-      assert_equal PROTOCOL_VERSION, response[:result][:protocolVersion]
+      assert_equal MCP::Constants::PROTOCOL_VERSION, response[:result][:protocolVersion]
       assert_equal false, response[:result][:capabilities][:tools][:listChanged]
     end
 
@@ -60,7 +60,7 @@ module MCP
         jsonrpc: MCP::Constants::JSON_RPC_VERSION,
         method: MCP::Constants::RequestMethods::INITIALIZE,
         params: {
-          protocolVersion: PROTOCOL_VERSION,
+          protocolVersion: MCP::Constants::PROTOCOL_VERSION,
           capabilities: {}
         },
         id: 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,7 @@ module MCPTest
         jsonrpc: MCP::Constants::JSON_RPC_VERSION,
         method: "initialize",
         params: {
-          protocolVersion: MCP::PROTOCOL_VERSION,
+          protocolVersion: MCP::Constants::PROTOCOL_VERSION,
           capabilities: {}
         },
         id: 1


### PR DESCRIPTION
For mcp-rb to be used more, it needs to be integrated with Rails.
This Pull Request (tiny) implements the MCP Client.

In this implementation, one MCP Client launches one MCP Server process and pipes standard I/O.

In this tests, we are pooling strings instead of stdin and stdout.
