### PR TITLE
Omit `nextCursor` key when no additional pages exist

### DIFF
--- a/lib/mcp/app/resource.rb
+++ b/lib/mcp/app/resource.rb
@@ -69,17 +69,17 @@ module MCP
 
         if page_size.nil?
           paginated = values[start_index..]
-          has_next = false
+          next_cursor = nil
         else
           paginated = values[start_index, page_size]
           has_next = start_index + page_size < values.length
+          next_cursor = has_next ? (start_index + page_size).to_s : nil
         end
 
-        result = {
-          resources: paginated.map { |r| format_resource(r) }
-        }
-        result[:nextCursor] = (start_index + page_size).to_s if has_next
-        result
+        {
+          resources: paginated.map { |r| format_resource(r) },
+          nextCursor: next_cursor
+        }.compact
       end
 
       def read_resource(uri)

--- a/lib/mcp/app/resource.rb
+++ b/lib/mcp/app/resource.rb
@@ -69,17 +69,17 @@ module MCP
 
         if page_size.nil?
           paginated = values[start_index..]
-          next_cursor = nil
+          has_next = false
         else
           paginated = values[start_index, page_size]
           has_next = start_index + page_size < values.length
-          next_cursor = has_next ? (start_index + page_size).to_s : nil
         end
 
-        {
-          resources: paginated.map { |r| format_resource(r) },
-          nextCursor: next_cursor
+        result = {
+          resources: paginated.map { |r| format_resource(r) }
         }
+        result[:nextCursor] = (start_index + page_size).to_s if has_next
+        result
       end
 
       def read_resource(uri)

--- a/lib/mcp/app/resource_template.rb
+++ b/lib/mcp/app/resource_template.rb
@@ -114,17 +114,17 @@ module MCP
 
         if page_size.nil?
           paginated = values[start_index..]
-          has_next = false
+          next_cursor = nil
         else
           paginated = values[start_index, page_size]
           has_next = start_index + page_size < values.length
+          next_cursor = has_next ? (start_index + page_size).to_s : nil
         end
 
-        result = {
-          resourceTemplates: paginated.map { |t| format_resource_template(t) }
-        }
-        result[:nextCursor] = (start_index + page_size).to_s if has_next
-        result
+        {
+          resourceTemplates: paginated.map { |t| format_resource_template(t) },
+          nextCursor: next_cursor
+        }.compact
       end
 
       private

--- a/lib/mcp/app/resource_template.rb
+++ b/lib/mcp/app/resource_template.rb
@@ -114,17 +114,17 @@ module MCP
 
         if page_size.nil?
           paginated = values[start_index..]
-          next_cursor = nil
+          has_next = false
         else
           paginated = values[start_index, page_size]
           has_next = start_index + page_size < values.length
-          next_cursor = has_next ? (start_index + page_size).to_s : nil
         end
 
-        {
-          resourceTemplates: paginated.map { |t| format_resource_template(t) },
-          nextCursor: next_cursor
+        result = {
+          resourceTemplates: paginated.map { |t| format_resource_template(t) }
         }
+        result[:nextCursor] = (start_index + page_size).to_s if has_next
+        result
       end
 
       private

--- a/lib/mcp/app/tool.rb
+++ b/lib/mcp/app/tool.rb
@@ -112,8 +112,11 @@ module MCP
       def list_tools(cursor: nil, page_size: 10)
         start = cursor ? cursor.to_i : 0
         paginated = tools.values[start, page_size]
-        next_cursor = (start + page_size < tools.length) ? (start + page_size).to_s : nil
-        {tools: paginated.map { |t| {name: t[:name], description: t[:description], inputSchema: t[:input_schema]} }, nextCursor: next_cursor}
+        has_next = start + page_size < tools.length
+
+        result = {tools: paginated.map { |t| {name: t[:name], description: t[:description], inputSchema: t[:input_schema]} }}
+        result[:nextCursor] = (start + page_size).to_s if has_next
+        result
       end
 
       # Calls a tool with the provided arguments

--- a/lib/mcp/app/tool.rb
+++ b/lib/mcp/app/tool.rb
@@ -112,11 +112,9 @@ module MCP
       def list_tools(cursor: nil, page_size: 10)
         start = cursor ? cursor.to_i : 0
         paginated = tools.values[start, page_size]
-        has_next = start + page_size < tools.length
 
-        result = {tools: paginated.map { |t| {name: t[:name], description: t[:description], inputSchema: t[:input_schema]} }}
-        result[:nextCursor] = (start + page_size).to_s if has_next
-        result
+        next_cursor = (start + page_size < tools.length) ? (start + page_size).to_s : nil
+        {tools: paginated.map { |t| {name: t[:name], description: t[:description], inputSchema: t[:input_schema]} }, nextCursor: next_cursor}.compact
       end
 
       # Calls a tool with the provided arguments

--- a/test/mcp/app/resource_template_test.rb
+++ b/test/mcp/app/resource_template_test.rb
@@ -49,7 +49,6 @@ module MCP
         result = @app.list_resource_templates
         templates = result[:resourceTemplates]
 
-
         assert_equal 10, templates.length
         assert_equal "/test0/{param_1}", templates.first[:uriTemplate]
         assert_equal "resource0", templates.first[:name]

--- a/test/mcp/app/resource_template_test.rb
+++ b/test/mcp/app/resource_template_test.rb
@@ -34,7 +34,7 @@ module MCP
         assert_equal "/test/{param_1}", templates.first[:uriTemplate]
         assert_equal "test_resource template", templates.first[:name]
         assert_equal "A test resource template", templates.first[:description]
-        assert_nil result[:nextCursor]
+        refute result.has_key?(:nextCursor)
       end
 
       def test_resource_templates_pagination
@@ -49,10 +49,11 @@ module MCP
         result = @app.list_resource_templates
         templates = result[:resourceTemplates]
 
+
         assert_equal 10, templates.length
         assert_equal "/test0/{param_1}", templates.first[:uriTemplate]
         assert_equal "resource0", templates.first[:name]
-        assert_nil result[:nextCursor]
+        refute result.has_key?(:nextCursor)
 
         # First page
         result = @app.list_resource_templates(page_size: 5)
@@ -66,7 +67,7 @@ module MCP
         assert_equal 5, result[:resourceTemplates].length
         assert_equal "/test5/{param_1}", result[:resourceTemplates].first[:uriTemplate]
         assert_equal "resource5", result[:resourceTemplates].first[:name]
-        assert_nil result[:nextCursor]
+        refute result.has_key?(:nextCursor)
       end
 
       def test_read_resource_template

--- a/test/mcp/app/resource_test.rb
+++ b/test/mcp/app/resource_test.rb
@@ -23,7 +23,7 @@ module MCP
         assert_equal "/test", resources.first[:uri]
         assert_equal "test_resource", resources.first[:name]
         assert_equal "A test resource", resources.first[:description]
-        assert_nil result[:nextCursor]
+        refute result.has_key?(:nextCursor)
       end
 
       def test_resources_pagination
@@ -39,7 +39,7 @@ module MCP
         assert_equal 10, result[:resources].length
         assert_equal "/test0", result[:resources].first[:uri]
         assert_equal "resource0", result[:resources].first[:name]
-        assert_nil result[:nextCursor]
+        refute result.has_key?(:nextCursor)
 
         # First page
         result = @app.list_resources(page_size: 5)
@@ -53,7 +53,7 @@ module MCP
         assert_equal 5, result[:resources].length
         assert_equal "/test5", result[:resources].first[:uri]
         assert_equal "resource5", result[:resources].first[:name]
-        assert_nil result[:nextCursor]
+        refute result.has_key?(:nextCursor)
       end
 
       def test_read_resource

--- a/test/mcp/app/tool_test.rb
+++ b/test/mcp/app/tool_test.rb
@@ -26,12 +26,14 @@ module MCP
         assert_equal 5, result[:tools].length
         assert_equal "tool0", result[:tools].first[:name]
         assert_equal "tool4", result[:tools].last[:name]
+        assert_equal "5", result[:nextCursor]
 
         # Second page
         result = @app.list_tools(page_size: 5, cursor: "5")
         assert_equal 5, result[:tools].length
         assert_equal "tool5", result[:tools].first[:name]
         assert_equal "tool9", result[:tools].last[:name]
+        refute result.has_key?(:nextCursor)
       end
 
       def test_register_tool


### PR DESCRIPTION
When running the inspector with `bunx @modelcontextprotocol/inspector $(pwd)/examples/hello_world.rb`, it was failing to function correctly upon reaching the last page of results.

It appears the issue stemmed from the API responding with `nextCursor: null` when no subsequent pages existed. 

While the server specifications are not explicitly defined, the client is designed to interpret the absence of the key as the end of results. Therefore, I've adjusted the implementation to omit the key

https://spec.modelcontextprotocol.io/specification/2024-11-05/server/utilities/pagination/#pagination-flow
