### PR TITLE
Remove unsupported capabilities

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -146,7 +146,6 @@ module MCP
         result: {
           protocolVersion: Constants::PROTOCOL_VERSION,
           capabilities: {
-            logging: {},
             resources: {
               subscribe: false,
               listChanged: false

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -147,9 +147,6 @@ module MCP
           protocolVersion: Constants::PROTOCOL_VERSION,
           capabilities: {
             logging: {},
-            prompts: {
-              listChanged: false
-            },
             resources: {
               subscribe: false,
               listChanged: false

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -55,6 +55,14 @@ module MCP
       assert_equal expected, response[:result][:capabilities][:resources]
     end
 
+    def test_does_not_support_prompts
+      start_server
+
+      response = send_message a_valid_initialize_request
+
+      refute_includes response[:result][:capabilities].keys, :prompts
+    end
+
     def test_returns_nothing_on_initialized_notification
       start_server
       send_message a_valid_initialize_request

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -63,6 +63,14 @@ module MCP
       refute_includes response[:result][:capabilities].keys, :prompts
     end
 
+    def test_does_not_support_logging
+      start_server
+
+      response = send_message a_valid_initialize_request
+
+      refute_includes response[:result][:capabilities].keys, :logging
+    end
+
     def test_returns_nothing_on_initialized_notification
       start_server
       send_message a_valid_initialize_request


### PR DESCRIPTION
Right now the library does not support prompts or logging - clients might be confused and send messages that will cause error responses.

So for now I changed the capabilities to reflect the actually supported features.

In the future maybe it would also be worth thinking about disabling capabilities dynamically which have no DSL definitions at al.... But that would be a different PR