### PR TITLE
Refactor to make each piece modular while retaining API

### DIFF
--- a/lib/mcp.rb
+++ b/lib/mcp.rb
@@ -5,23 +5,30 @@ require "json"
 
 require_relative "mcp/version"
 require_relative "mcp/constants"
+require_relative "mcp/autorun"
 require_relative "mcp/app"
 require_relative "mcp/server"
 require_relative "mcp/delegator"
 require_relative "mcp/client"
 
 module MCP
+  extend MCP::Autorun
+  @app_file = cleaned_caller(1).flatten.first
   class << self
     attr_reader :server
 
     def initialize_server(name:, **options)
       @server ||= Server.new(name: name, **options)
     end
+
+    def run?
+      File.expand_path($PROGRAM_NAME) == File.expand_path(@app_file) && $ERROR_INFO.nil? && $stdin.stat.readable?
+    end
   end
 
   # require 'mcp' したファイルで最後に到達したら実行されるようにするため
   # https://docs.ruby-lang.org/ja/latest/method/Kernel/m/at_exit.html
-  at_exit { server.serve(Server::StdioClientConnection.new) if $ERROR_INFO.nil? && server }
+  at_exit { server.serve(Server::StdioClientConnection.new) if run? && $ERROR_INFO.nil? && server }
 
   def self.new(**options, &block)
     @server = Server.new(**options)

--- a/lib/mcp.rb
+++ b/lib/mcp.rb
@@ -15,10 +15,8 @@ module MCP
   extend MCP::Autorun
   @app_file = cleaned_caller(1).flatten.first
   class << self
-    attr_reader :server
-
-    def initialize_server(name:, **options)
-      @server ||= Server.new(name: name, **options)
+    def server
+      @server ||= Server.new(App.new)
     end
 
     def run?

--- a/lib/mcp/app.rb
+++ b/lib/mcp/app.rb
@@ -9,5 +9,40 @@ module MCP
     include Resource
     include ResourceTemplate
     include Tool
+
+    class << self
+      def name(value = nil)
+        return @name if value.nil?
+
+        @name = value
+      end
+
+      def version(value = nil)
+        return @version if value.nil?
+
+        @version = value
+      end
+
+      def reset!
+        super
+        @name = nil
+        @version = nil
+        @tools = nil
+        @resources = nil
+        @resource_templates = nil
+      end
+    end
+
+    def settings
+      self.class
+    end
+
+    def name
+      settings.name
+    end
+
+    def version
+      settings.version
+    end
   end
 end

--- a/lib/mcp/autorun.rb
+++ b/lib/mcp/autorun.rb
@@ -1,0 +1,25 @@
+module MCP
+  # This is from Sinatra to detect if the app should run at_exit
+  module Autorun
+    CALLERS_TO_IGNORE = [ # :nodoc:
+      %r{/mcp(/(app|autorun))?\.rb$},   # all sinatra code
+      /^\(.*\)$/,                                         # generated code
+      /\/bundled_gems.rb$/,                               # ruby >= 3.3 with bundler >= 2.5
+      %r{rubygems/(custom|core_ext/kernel)_require\.rb$}, # rubygems require hacks
+      /active_support/,                                   # active_support require hacks
+      %r{bundler(/(?:runtime|inline))?\.rb},              # bundler require hacks
+      /<internal:/,                                       # internal in ruby >= 1.9.2
+      %r{zeitwerk/(core_ext/)?kernel\.rb}                 # Zeitwerk kernel#require decorator
+    ].freeze
+
+    def callers_to_ignore
+      CALLERS_TO_IGNORE
+    end
+
+    def cleaned_caller(keep = 3)
+      caller(1)
+        .map! { |line| line.split(/:(?=\d|in )/, 3)[0, keep] }
+        .reject { |file, *_| callers_to_ignore.any? { |pattern| file =~ pattern } }
+    end
+  end
+end

--- a/lib/mcp/delegator.rb
+++ b/lib/mcp/delegator.rb
@@ -5,12 +5,7 @@ module MCP
     def self.delegate(*methods)
       methods.each do |method_name|
         define_method(method_name) do |*args, **kwargs, &block|
-          # name が呼ばれたら Server インスタンスを生成
-          # もうすこしいい感じにしたい
-          if method_name == :name && !MCP.server
-            MCP.initialize_server(name: args.first || "default")
-          end
-          MCP.server.send(method_name, *args, **kwargs, &block)
+          MCP::App.send(method_name, *args, **kwargs, &block)
         end
       end
     end

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -9,39 +9,22 @@ require_relative "server/client_connection"
 require_relative "server/stdio_client_connection"
 
 module MCP
+  # A Server handles MCP requests from an MCP client using the App.
   class Server
-    attr_writer :name, :version
+    attr_reader :app
 
-    def initialize(name:, version: "0.1.0")
-      @name = name
-      @version = version
-      @app = App.new
+    def initialize(app)
+      @app = app
       @initialized = false
       @message_validator = MessageValidator.new protocol_version: Constants::PROTOCOL_VERSION
     end
 
-    def name(value = nil)
-      return @name if value.nil?
-
-      @name = value
+    def name
+      @app.name
     end
 
-    def version(value = nil)
-      return @version if value.nil?
-
-      @version = value
-    end
-
-    def tool(name, &block)
-      @app.register_tool(name, &block)
-    end
-
-    def resource(uri, &block)
-      @app.register_resource(uri, &block)
-    end
-
-    def resource_template(uri_template, &block)
-      @app.register_resource_template(uri_template, &block)
+    def version
+      @app.version
     end
 
     def initialized?
@@ -185,8 +168,8 @@ module MCP
             }
           },
           serverInfo: {
-            name: @name,
-            version: @version
+            name: @app.name,
+            version: @app.version
           }
         }
       }

--- a/test/mcp/app/resource_test.rb
+++ b/test/mcp/app/resource_test.rb
@@ -5,12 +5,20 @@ require_relative "../../test_helper"
 module MCP
   class App
     class ResourceTest < MCPTest::TestCase
+      class TestApp
+        include MCP::App::Resource
+      end
+
       def setup
-        @app = App.new
+        @app = TestApp.new
+      end
+
+      def teardown
+        TestApp.reset!
       end
 
       def test_register_and_list_resources
-        @app.register_resource("/test") do
+        TestApp.resource("/test") do
           name "test_resource"
           description "A test resource"
           call { "test content" }
@@ -28,7 +36,7 @@ module MCP
 
       def test_resources_pagination
         10.times do |i|
-          @app.register_resource("/test#{i}") do
+          TestApp.resource("/test#{i}") do
             name "resource#{i}"
             call { "content#{i}" }
           end
@@ -57,7 +65,7 @@ module MCP
       end
 
       def test_read_resource
-        @app.register_resource("/test") do
+        TestApp.resource("/test") do
           name "test_resource"
           call { "test content" }
         end
@@ -72,21 +80,21 @@ module MCP
       end
 
       def test_invalid_resource_registration
-        error = assert_raises(ArgumentError) { @app.register_resource(nil) }
+        error = assert_raises(ArgumentError) { TestApp.resource(nil) {} }
         assert_match(/Resource URI cannot be nil or empty/, error.message)
 
-        error = assert_raises(ArgumentError) { @app.register_resource("") }
+        error = assert_raises(ArgumentError) { TestApp.resource("") {} }
         assert_match(/Resource URI cannot be nil or empty/, error.message)
 
         error = assert_raises(ArgumentError) do
-          @app.register_resource("/test") do
+          TestApp.resource("/test") do
             # nameとhandlerが設定されていない
           end
         end
         assert_match(/Handler must be provided/, error.message)
 
         error = assert_raises(ArgumentError) do
-          @app.register_resource("/test") do
+          TestApp.resource("/test") do
             call { "test" }
             # nameが設定されていない
           end

--- a/test/mcp/app/tool_test.rb
+++ b/test/mcp/app/tool_test.rb
@@ -5,13 +5,21 @@ require_relative "../../test_helper"
 module MCP
   class App
     class ToolTest < MCPTest::TestCase
+      class TestApp
+        include MCP::App::Tool
+      end
+
       def setup
-        @app = App.new
+        @app = TestApp.new
+      end
+
+      def teardown
+        TestApp.reset!
       end
 
       def test_tools_pagination
         10.times do |i|
-          @app.register_tool("tool#{i}") do
+          TestApp.tool("tool#{i}") do
             description "Tool #{i}"
             argument :value, String, required: true, description: "Value for tool #{i}"
 
@@ -37,7 +45,7 @@ module MCP
       end
 
       def test_register_tool
-        tool = @app.register_tool("greet") do
+        tool = TestApp.tool("greet") do
           description "Greet someone by name"
           argument :name, String, required: true, description: "Name to greet"
 
@@ -70,7 +78,7 @@ module MCP
       end
 
       def test_register_tool_with_multiple_arguments
-        tool = @app.register_tool("format_greeting") do
+        tool = TestApp.tool("format_greeting") do
           description "Format a greeting with title and name"
           argument :title, String, required: true, description: "Title (Mr./Ms./Dr. etc.)"
           argument :first_name, String, required: true, description: "First name"
@@ -144,7 +152,7 @@ module MCP
 
       def test_tool_without_handler
         error = assert_raises(ArgumentError) do
-          @app.register_tool("invalid") do
+          TestApp.tool("invalid") do
             description "Invalid tool without handler"
           end
         end
@@ -153,7 +161,7 @@ module MCP
 
       def test_tool_with_invalid_name
         error = assert_raises(ArgumentError) do
-          @app.register_tool(nil) do
+          TestApp.tool(nil) do
             description "Invalid tool"
             call do |args|
               "test"
@@ -164,7 +172,7 @@ module MCP
       end
 
       def test_tool_with_nested_object
-        tool = @app.register_tool("create_user") do
+        tool = TestApp.tool("create_user") do
           description "Create a user with details"
           argument :user, required: true do
             argument :username, String, required: true, description: "Username"
@@ -229,7 +237,7 @@ module MCP
 
       # Test for a tool with an array of simple types
       def test_tool_with_array_argument
-        @app.register_tool("sum_numbers") do
+        tool = TestApp.tool("sum_numbers") do
           description "Sum an array of numbers"
           argument :numbers, Array, items: Integer, description: "Array of numbers to sum"
 
@@ -279,7 +287,7 @@ module MCP
 
       # Test for a tool with an array of objects
       def test_tool_with_array_of_objects
-        @app.register_tool("list_users") do
+        tool = TestApp.tool("list_users") do
           description "List users with their details"
           argument :users, Array do
             argument :name, String, required: true, description: "User's name"

--- a/test/mcp/app_test.rb
+++ b/test/mcp/app_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module MCP
+  class ServerTest < MCPTest::TestCase
+    def teardown
+      App.reset!
+    end
+
+    def test_app_version
+      App.version("1.2.3")
+      app = App.new
+
+      assert_equal "1.2.3", app.version
+    end
+
+    def test_app_name_and_version
+      App.name("special_test_server")
+      App.version("1.4.1")
+
+      app = App.new
+
+      assert_equal "special_test_server", app.name
+      assert_equal "1.4.1", app.version
+    end
+
+    class MyApp < MCP::App
+      name "sub_app"
+      version "1.0.0"
+
+      tool "neat_tool" do
+        description "A tool that does something neat"
+        argument :name, String, required: true
+        call { |args| "Hello, #{args[:name]}!" }
+      end
+    end
+
+    def test_inherited_app
+
+      app = MyApp.new
+      assert_equal "sub_app", app.name
+      assert_equal "1.0.0", app.version
+      assert_equal({content: [{type: "text", text: "Hello, world!"}], isError: false}, app.call_tool("neat_tool", name: "world"))
+    end
+  end
+end

--- a/test/mcp/delegator_test.rb
+++ b/test/mcp/delegator_test.rb
@@ -4,27 +4,27 @@ require_relative "../test_helper"
 
 module MCP
   class DelegatorTest < MCPTest::TestCase
-    def test_server_version
-      server = build_test_server
-      server.version "1.2.3"
+    module TestModule
+      extend MCP::Delegator
+    end
 
-      assert_equal "1.2.3", server.version
+    def setup
+      @dsl = TestModule
+      @app = MCP::App.new
+    end
 
-      initialize_response = initialize_server(server)
-      assert_equal "1.2.3", initialize_response[:result][:serverInfo][:version]
+    def teardown
+      MCP::App.reset!
     end
 
     def test_tool_registration
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      server.tool("test_tool") do
+      @dsl.tool("test_tool") do
         description "A test tool"
         argument :value, String, required: true, description: "Test value"
         call { |args| args[:value].to_s }
       end
 
-      tools = server.instance_variable_get(:@app).list_tools[:tools]
+      tools = MCP::App.new.list_tools[:tools]
 
       assert_equal 1, tools.size
       assert_equal "test_tool", tools.first[:name]
@@ -32,16 +32,13 @@ module MCP
     end
 
     def test_resource_registration
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      server.resource("test_resource") do
+      @dsl.resource("test_resource") do
         name "test_resource"
         description "A test resource"
         call { "test content" }
       end
 
-      resources = server.instance_variable_get(:@app).list_resources[:resources]
+      resources = @app.list_resources[:resources]
 
       assert_equal 1, resources.size
       assert_equal "test_resource", resources.first[:name]
@@ -49,16 +46,13 @@ module MCP
     end
 
     def test_resource_template_registration
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      server.resource_template("content://{test_variable}") do
+      @dsl.resource_template("content://{test_variable}") do
         name "test_template"
         description "A test resource"
         call { |args| "test content #{args[:test_variable]}" }
       end
 
-      templates = server.instance_variable_get(:@app).list_resource_templates[:resourceTemplates]
+      templates = @app.list_resource_templates[:resourceTemplates]
 
       assert_equal 1, templates.size
       assert_equal "test_template", templates.first[:name]
@@ -66,68 +60,52 @@ module MCP
     end
 
     def test_tool_block_execution
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      server.tool("echo") do
+      @dsl.tool("echo") do
         description "Echo a message"
         argument :message, String, required: true, description: "Message to echo"
         call { |args| args[:message] }
       end
 
-      result = server.instance_variable_get(:@app).call_tool("echo", message: "hello").dig(:content, 0, :text)
+      result = @app.call_tool("echo", message: "hello").dig(:content, 0, :text)
 
       assert_equal "hello", result
     end
 
     def test_resource_block_execution
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      server.resource("content") do
+      @dsl.resource("content") do
         name "content"
         call { "test content" }
       end
 
-      result = server.instance_variable_get(:@app).read_resource("content").dig(:contents, 0, :text)
+      result = @app.read_resource("content").dig(:contents, 0, :text)
 
       assert_equal "test content", result
     end
 
     def test_resource_template_block_execution
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      server.resource_template("content://{test_variable}") do
+      @dsl.resource_template("content://{test_variable}") do
         name "content"
         call { |args| "test content #{args[:test_variable]}" }
       end
 
-      result = server.instance_variable_get(:@app).read_resource("content://test").dig(:contents, 0, :text)
+      result = @app.read_resource("content://test").dig(:contents, 0, :text)
 
       assert_equal "test content test", result
     end
 
     def test_tool_registration_with_invalid_name
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      assert_raises(ArgumentError) { server.tool(nil) { "test" } }
-      assert_raises(ArgumentError) { server.tool("") { "test" } }
+      assert_raises(ArgumentError) { @dsl.tool(nil) { "test" } }
+      assert_raises(ArgumentError) { @dsl.tool("") { "test" } }
     end
 
     def test_resource_registration_with_invalid_name
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      assert_raises(ArgumentError) { server.resource(nil) { "test" } }
+      assert_raises(ArgumentError) { @dsl.resource(nil) { "test" } }
+      assert_raises(ArgumentError) { @dsl.resource("") { "test" } }
     end
 
     def test_resource_template_registration_with_invalid_name
-      server = Server.new(name: "test_server")
-      initialize_server(server)
-
-      assert_raises(ArgumentError) { server.resource_template(nil) { "test" } }
+      assert_raises(ArgumentError) { @dsl.resource_template(nil) { "test" } }
+      assert_raises(ArgumentError) { @dsl.resource_template("") { "test" } }
     end
   end
 end

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -4,6 +4,19 @@ require_relative "../test_helper"
 
 module MCP
   class ServerTest < MCPTest::TestCase
+    def teardown
+      App.reset!
+    end
+
+    def test_server_version
+      prepare_server(version: "1.2.3")
+
+      assert_equal "1.2.3", @server.version
+
+      initialize_response = initialize_server(@server)
+      assert_equal "1.2.3", initialize_response[:result][:serverInfo][:version]
+    end
+
     def test_basic_server_info
       prepare_server(name: "special_test_server", version: "1.4.1")
 
@@ -258,11 +271,9 @@ module MCP
     end
 
     def prepare_server(name: "test_server", version: nil)
-      kwargs = {
-        name: name,
-        version: version
-      }.compact
-      @server = Server.new(**kwargs)
+      App.name(name) if name
+      App.version(version) if version
+      @server = Server.new(App.new)
     end
 
     def send_message(message)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,10 +8,12 @@ require_relative "../lib/mcp"
 
 module MCPTest
   class TestCase < Minitest::Test
-    protected
+    def setup
+      MCP::App.reset!
+    end
 
-    def build_test_server
-      MCP::Server.new(name: "test_server")
+    def teardown
+      MCP::App.reset!
     end
 
     def initialize_server(server)


### PR DESCRIPTION
Hi!  I liked what you've written. I wanted to be able to use the Server or the App/Tool/Resource as separate pieces apart from the global dsl, so I broke them apart into modular pieces.

I am offering the changes back for you to merge if you like them. I tried to maintain exact compatibility with your public API while adding the ability to create an app more like `sinatra/base`

With this version you can use the app the normal way as before, or you can do as follows (mixing and matching the API, or using the global methods or not).

```ruby
class MyMCP << MCP::App
  name "example"
  version: "1.2.3"

  tool(MyTool.new) # any object that responds to #to_h that returns the correct format

  resource(MyResource.new) # this allows users to define more complex resources without a giant file

  tool("easy_tool_with_dsl") do # the old dsl works exactly the same
    argument :first_name, String, required: false, description: "First name"
    argument :last_name, String, required: false, description: "Last name"
    call do
      # etc
    end
  end

  # it also accept a plain hash
  app.tool(name: "create-user", description: "create a user", call: ->(args) { args[:name] }, ... )
end

app = MyMCP.new
transport = MCP::Server::StdioClientConnection.new
MCP::Server.new(app).serve(transport)
```

All of this should work in the Sinatra-style dsl too.
