### PR TITLE
Use Addressable::Template for RFC 6570 URI template processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+gemspec
+
 gem "json"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,14 @@
+PATH
+  remote: .
+  specs:
+    mcp-rb (0.3.2)
+      addressable (~> 2.8.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ansi (1.5.0)
     ast (2.4.2)
     builder (3.3.0)
@@ -18,6 +26,7 @@ GEM
     parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
+    public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
     regexp_parser (2.10.0)
@@ -61,6 +70,7 @@ PLATFORMS
 
 DEPENDENCIES
   json
+  mcp-rb!
   minitest
   minitest-reporters
   minitest-snapshots

--- a/mcp-rb.gemspec
+++ b/mcp-rb.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
     CHANGELOG.md
   ])
   spec.require_paths = ["lib"]
+
+  spec.add_dependency "addressable", "~> 2.8.0"
 end


### PR DESCRIPTION
Nothing beats a full implementation of the RFC. 😁 

MCP spec says that it follows RFC 6570 for uri templates, so using Addressable allows for full use of URI templating like splats and query matching.